### PR TITLE
Removed compare-versions dependency.

### DIFF
--- a/lib/handler-factory.js
+++ b/lib/handler-factory.js
@@ -1,9 +1,6 @@
 'use strict'
 
 const _ = require('lodash');
-const vComp = require('compare-versions');
-
-const requiresName = () => vComp('6.8.0', process.version.substring(1)) >= 0;
 
 /**
  * TODO: Probably refactor. Had to rewrite to native node v4 from magical v7
@@ -18,21 +15,10 @@ class HandlerFactory {
     if (!_.isFunction(handler)) throw new Error('No valid handlers were provided');
 
     if (_.isEmpty(name)) {
-      let msg;
-
-      if (requiresName()) {
-        msg = [
-          'Node version is <6.8.0 so named functions are required.',
-          'If you use anonymous functions you must use registerByName()'
-        ].join('\n');
-      } else {
-        msg = [
-          'Function name is unknown. Handlers can\'t be anonymous',
-          'If you use anonymous functions you must use registerByName()'
-        ].join('\n');
-      }
-
-      throw new Error(msg);
+      throw new Error(
+        "Function name is unknown. Handlers can\'t be anonymous\n"+
+        "If you use anonymous functions you must use registerByName()"
+      );
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "sinon-test": "^1.0.1"
   },
   "dependencies": {
-    "compare-versions": "^3.0.0",
     "lodash": "^4.17.4"
   },
   "keywords": [

--- a/test/lib/handler-factory.js
+++ b/test/lib/handler-factory.js
@@ -45,12 +45,11 @@ describe('HandlerFactory', () => {
     });
 
     it('should throw an error when given an empty name', () => {
-      let vMsg = 'Node version is <6.8.0 so named functions are required.';
       let nMsg = 'Function name is unknown. Handlers can\'t be anonymous';
       let rMsg = 'If you use anonymous functions you must use registerByName()';
 
       expect(() => lambda._validateHandler(undefined, console.log)).to.throw(
-        new RegExp(`(${vMsg}|${nMsg})\n${rMsg}`)
+        new RegExp(`(${nMsg})\n${rMsg}`)
       );
     });
   });


### PR DESCRIPTION
Updated name handler function logic. There was really no need for in depth checking. The function simply should require a name for the function.
Updated test to no longer look for node version error message.

This resolves issue #6 